### PR TITLE
Spike/query refactor

### DIFF
--- a/client/src/routes/recipes/[id].svelte
+++ b/client/src/routes/recipes/[id].svelte
@@ -27,18 +27,20 @@
 
   const { session } = stores(); // session data is stored here
 
-  // console.log('the session is:', $session); // access it like this 
-
-  // // user info, including id, is stored in a user object in the session
-  // console.log('the session is:', $session);
-  // console.log('the user ID is:', $session.user.id);
-  // console.log('the user email is:', $session.user.email_address);
-
   export let recipeDetails;
   export let id;
 
   const {
-    recipe: [{ title, description, image_url, difficulty, favourite_count, duration, servings }],
+    recipe: [{
+      title,
+      description,
+      image_url,
+      difficulty,
+      userFavourite,
+      favourite_count,
+      duration,
+      servings
+    }],
     emojiReactions,
     ingredients,
     instructions
@@ -72,8 +74,8 @@
         recipe_id: id
         }),
       });
-      recipeDetails.recipe[0].userFavourite = true
-      recipeDetails.recipe[0].favourite_count++;
+      userFavourite = true
+      favourite_count++;
       // goto('/') //redirect to user's recipes (once built)
     }
     catch (error) {
@@ -89,8 +91,8 @@
         method: "DELETE",
   
       });
-      recipeDetails.recipe[0].userFavourite = false
-      recipeDetails.recipe[0].favourite_count--;
+      userFavourite = false
+      favourite_count--;
       // goto('/') //redirect to user's recipes (once built)
     }
     catch (error) {
@@ -106,14 +108,14 @@
 
 <h3>{title}</h3>
 <p>{description}</p>
-{#each emojiReactions as {name, emoji, count}}
-  <div>{emoji}x{count}</div>
-{/each}
-{#if image_url}
-  <img style="width: 30%" src="{image_url}" alt="recipe">
-{/if}
 
-{#if recipeDetails.recipe[0].userFavourite}
+{#each emojiReactions as emojiReaction }
+  <Emoji recipeID={id} {emojiReaction} />
+{/each}
+
+<img style="width: 30%" src="{image_url}" alt="recipe">
+
+{#if userFavourite}
 <Button  on:click={() => unfavouriteRecipe()} filled>Unfavourite Recipe</Button>
 {:else}
 <Button  on:click={() => favouriteRecipe()} outline>Favourite Recipe</Button>
@@ -142,4 +144,3 @@
   {/each}
 </ul>
 <Button on:click={() => deleteRecipe()}>Delete a Recipe</Button>
-

--- a/client/src/routes/recipes/[id].svelte
+++ b/client/src/routes/recipes/[id].svelte
@@ -37,8 +37,13 @@
   export let recipeDetails;
   export let id;
 
-  console.log('recipe details:', recipeDetails);
-
+  const {
+    recipe: [{ title, description, image_url, difficulty, favourite_count, duration, servings }],
+    emojiReactions,
+    ingredients,
+    instructions
+ } = recipeDetails
+  
   async function deleteRecipe() {
     console.log('the deleted recipe id is: ', id)
     // const { id } = page.params;
@@ -99,14 +104,14 @@
 	<title>Bite Size</title>
 </svelte:head>
 
-<h3>{recipeDetails.recipe[0].title}</h3>
-<p>{recipeDetails.recipe[0].description}</p>
-
-{#each recipeDetails.emojiReactions as emojiReaction }
-  <Emoji recipeID={id} {emojiReaction} />
+<h3>{title}</h3>
+<p>{description}</p>
+{#each emojiReactions as {name, emoji, count}}
+  <div>{emoji}x{count}</div>
 {/each}
-
-<img style="width: 30%" src="{recipeDetails.recipe[0].image_url}" alt="recipe">
+{#if image_url}
+  <img style="width: 30%" src="{image_url}" alt="recipe">
+{/if}
 
 {#if recipeDetails.recipe[0].userFavourite}
 <Button  on:click={() => unfavouriteRecipe()} filled>Unfavourite Recipe</Button>
@@ -114,14 +119,14 @@
 <Button  on:click={() => favouriteRecipe()} outline>Favourite Recipe</Button>
 {/if}
 
-<p>Difficulty: {recipeDetails.recipe[0].difficulty}</p>
-<p>Favs: {recipeDetails.recipe[0].favourite_count}</p>
-<p>Duration: {recipeDetails.recipe[0].duration} minutes</p>
-<p>Servings: {recipeDetails.recipe[0].servings}</p>
+<p>Difficulty: {difficulty}</p>
+<p>Favs: {favourite_count}</p>
+<p>Duration: {duration} minutes</p>
+<p>Servings: {servings}</p>
 
 <h3>Ingredients:</h3>
 <ul>
-  {#each recipeDetails.ingredients as { name, unit, quantity }, id}
+  {#each ingredients as { name, unit, quantity }, id}
     <li>
       {quantity} x {unit} of {name} 
     </li>
@@ -130,7 +135,7 @@
 
 <h3>Instructions:</h3>
 <ul>
-  {#each recipeDetails.instructions as { instruction }}
+  {#each instructions as { instruction }}
     <li>
       {instruction}
     </li>

--- a/client/src/routes/recipes/[id].svelte
+++ b/client/src/routes/recipes/[id].svelte
@@ -30,7 +30,7 @@
   export let recipeDetails;
   export let id;
 
-  const {
+  let {
     recipe: [{
       title,
       description,

--- a/client/src/routes/recipes/new/index.svelte
+++ b/client/src/routes/recipes/new/index.svelte
@@ -22,12 +22,11 @@
     FileDropzone,
   } from "attractions";
 
-  
-  let hours;
-  let minutes;
+  let hours = 0;
+  let minutes = 0;
   let title = null;
   let difficulty = 2;
-  let duration = null;
+  let duration = 0;
   let image_url = null;
   let servings = null;
   let description = null;
@@ -41,22 +40,19 @@
   const difficultyNames = ["Beginner", "Intermediate", "Advanced"];
 
   const handleSubmit = async () => {
-   
-    // console.log(
-    //   title,
-    //   difficulty,
-    //   duration,
-    //   image_url,
-    //   servings,
-    //   description,
-    //   instructionSteps
-    // );
-    console.log('KEY', key, "PAGE", page)
-    duration = (hours * 60) + minutes;
+    if (hours && minutes) {
+      duration = (hours * 60) + minutes
+    } else if (!minutes && hours) {
+      duration = hours * 60
+    } else if (!hours && minutes) {
+      duration = minutes
+    } else {
+      duration
+    }
     //Create an if statement to make sure we have everything to make a recipe...
     loadingState = true
       try {
-        await fetch("http://localhost:5001/recipes", {
+        const res = await fetch("http://localhost:5001/recipes", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -73,7 +69,9 @@
           }),
         });
         loadingState = false
-        goto('/recipes') //redirect to user's recipes (once built)
+        const { recipe: { id } } = await res.json()
+
+        goto(`/recipes/${id}`)
       }
       catch (error) {
         console.error(error)

--- a/client/src/server.js
+++ b/client/src/server.js
@@ -13,6 +13,7 @@ const { createProxyMiddleware } = require('http-proxy-middleware');
 const { PORT, NODE_ENV, CLOUDINARY, CLOUDKEY } = process.env;
 const dev = NODE_ENV === 'development';
 
+
 polka()
 	.use(
     json(),

--- a/server/plugins/recipe-queries/index.js
+++ b/server/plugins/recipe-queries/index.js
@@ -1,0 +1,106 @@
+const fastifyPlugin = require('fastify-plugin')
+
+async function recipeQueries (fastify) {
+  const { pg } = fastify
+
+  fastify.decorate('recipeQuery', {
+    getEmojis: async (recipeId) => {
+      return pg.query(`
+        SELECT e.*, count(u.*) AS count FROM emojis e
+        LEFT JOIN user_emoji_reactions u ON e.id = u.emoji_id
+        AND u.recipe_id = $1
+        GROUP BY e.id;
+      `, [recipeId])
+    },
+    getAll: async () => {
+      return pg.query(`
+        SELECT r.*, u.username, count(f.*) AS favourites FROM recipes r
+        JOIN users u ON u.id = r.user_id
+        JOIN favourites f ON r.id = f.recipe_id
+        GROUP BY r.id, u.username
+        ORDER BY r.id
+      `) 
+    },
+    postNewRecipe: async (newRecipe) => {
+      const {
+        title,
+        difficulty,
+        duration,
+        image_url,
+        servings,
+        description,
+        instructionSteps,
+        ingredientList,
+        unit_of_measure,
+        quantity
+      } = newRecipe
+    
+      const { rows: recipe } = await pg.transact(async client => {
+        return client.query(`
+            INSERT INTO recipes (title, difficulty_id, duration, image_url, servings, description)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING *;
+          `, [title, difficulty, duration, image_url, servings, description]
+        )
+      })
+      console.log(recipe[0]);
+      const recipeId = recipe[0].id;
+
+      const instructions = await pg.transact(async client => {
+        const newInstructions = []
+        for (const [index, step] of instructionSteps.entries()) {
+          if (step) {
+            const { rows } = await client.query(`
+              INSERT INTO instructions (instruction, step, recipe_id)
+              VALUES ($1, $2, $3)
+              RETURNING *;
+            `, [step, (index + 1), recipeId]
+            )
+            newInstructions.push(rows[0])
+          }
+        }
+        return newInstructions
+      })
+    
+       const ingredients = await pg.transact(async client => {
+        const newIngredients = []
+        for (const ingredient of ingredientList) {
+          if (ingredient) {
+            const { rows } = await client.query(`
+              INSERT INTO ingredients (name) 
+              VALUES ($1)
+              RETURNING *;
+            `, [ingredient])
+    
+            const ingredientId = rows[0].id
+    
+            const { rows: newQuantity } = await client.query(`
+              INSERT INTO recipe_ingredients (recipe_id, ingredient_id, quantity, unit_of_measure_id) 
+              VALUES ($1, $2, $3, $4)
+              RETURNING *;
+            `, [recipeId, ingredientId, quantity, unit_of_measure])
+
+            newIngredients.push({
+              ingredient: rows[0],
+              quantityId: newQuantity[0].id,
+              quantity: newQuantity.quantity,
+              unitOfMeasureId: newQuantity.unit_of_measure_id
+            })
+          }
+        }
+        return newIngredients
+      })
+      return { recipe: recipe[0], instructions, ingredients }
+    }
+  })
+}
+
+module.exports = fastifyPlugin(recipeQueries, {
+  name: 'database-queries',
+  decorators: {
+    fastify: ['pg']
+  },
+  dependencies: [
+    'fastify-postgres'
+  ]
+})

--- a/server/routes/recipes/index.js
+++ b/server/routes/recipes/index.js
@@ -3,7 +3,7 @@ const   { addEmojiReaction, removeEmojiReaction } = require('../../src/db/emoji_
 
 
 const recipesRoutes = async (fastify) => {
-  const { dbQuery } = fastify
+  const { recipeQuery } = fastify
 
   fastify.get('/recipes', async (req, reply) => {
     const rows = await getRecipes(fastify);
@@ -28,8 +28,9 @@ const recipesRoutes = async (fastify) => {
 
   fastify.post('/recipes', async (req, reply) => {
     const { body } = req
-    await postNewRecipe(fastify, body)
-    reply.code(204)
+    const newRecipe = await recipeQuery.postNewRecipe(body)
+    console.log(newRecipe);
+    reply.send(newRecipe)
   })
                
   fastify.delete('/recipes/:id', async (req, reply) => {


### PR DESCRIPTION
Did a refactor on the recipe ID page to pull out each element of the recipe for easier handling on page.

Moved a few queries to the plugins folder as reference of how to build a method for fastify.
The old plugin's still work if we call them from the queries folder in src/db.

Change route for fastify to grab recipequerys folder in plugins
