### PR TITLE
BUG: Fav count in My favs is fixed

### DIFF
--- a/server/src/db/favourites_queries.js
+++ b/server/src/db/favourites_queries.js
@@ -1,11 +1,12 @@
 const getUserFavourites = async (fastify, user_id) => {
   const client = await fastify.pg.connect()
   const { rows } = await client.query(
-    `SELECT r.*, u.username, count(f.*) AS favourites FROM recipes r
+    `SELECT r.*, u.username, totfav.tf AS favourites FROM recipes r
     JOIN users u ON u.id = r.user_id
-    JOIN favourites f ON r.id = f.recipe_id
+    LEFT JOIN favourites f ON f.user_id = u.id
+    JOIN (select recipe_id, count(user_id) tf from favourites group by recipe_id) totfav ON r.id = totfav.recipe_id
     WHERE f.user_id = $1
-    GROUP BY r.id, u.username
+    GROUP BY r.id, u.username, totfav.tf
     ORDER BY r.id`, [user_id]
   )
   client.release()


### PR DESCRIPTION
In "My Favourites" tab, the recipes displayed now reflect the total number of favourites per recipe. previously the fav num was limited to 1, the number of times the logged-in user had favourited the recipe.


closes issue #70 