### PR TITLE
New Recipe form uses a textarea for ingredients

### DIFF
--- a/client/src/routes/recipes/new/index.svelte
+++ b/client/src/routes/recipes/new/index.svelte
@@ -193,15 +193,17 @@
     <output for="difficulty-slider">{difficultyNames[difficulty - 1]}</output>
   </FormField>
 
-  {#each ingredientList as ingredient, index}
+  <!-- {#each ingredientList as ingredient, index} -->
     <FormField name="Ingredients" required>
-      <TextField bind:value={ingredientList[index]} />
+      <!-- <TextField bind:value={ingredientList[index]} /> -->
+
+      <textarea rows="8" cols="50" name="Ingredients" bind:value={ingredientList} placeholder="Put each ingredient on its own line."></textarea>
 
     </FormField>
-  {/each}
+  <!-- {/each} -->
 
-  <Button on:click={addIngredient}>Add Ingredient</Button>
-  <Button on:click={removeIngredient}>Remove</Button>
+  <!-- <Button on:click={addIngredient}>Add Ingredient</Button> -->
+  <!-- <Button on:click={removeIngredient}>Remove</Button> -->
 
   {#if !imageUrl}
     <FileDropzone accept="image/*" max={1} on:change={uploadImage}>

--- a/server/migrations/1618446528057_seed-units-of-measure.js
+++ b/server/migrations/1618446528057_seed-units-of-measure.js
@@ -1,0 +1,28 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+
+  // update id = 2 to cup
+  pgm.sql(`UPDATE units_of_measure SET unit = 'cup' WHERE id=2`)
+  
+  // update id = 3 to ounce
+  pgm.sql(`UPDATE units_of_measure SET unit = 'ounce' WHERE id=3`)
+
+  // insert the rest
+  pgm.sql(`INSERT INTO units_of_measure (unit) VALUES ('gallon');
+INSERT INTO units_of_measure (unit) VALUES ('gram');
+INSERT INTO units_of_measure (unit) VALUES ('kilogram');
+INSERT INTO units_of_measure (unit) VALUES ('liter');
+INSERT INTO units_of_measure (unit) VALUES ('milliliter');
+INSERT INTO units_of_measure (unit) VALUES ('pint');
+INSERT INTO units_of_measure (unit) VALUES ('pound');
+INSERT INTO units_of_measure (unit) VALUES ('quart');
+INSERT INTO units_of_measure (unit) VALUES ('tablespoon');
+INSERT INTO units_of_measure (unit) VALUES ('teaspoon');`)
+};
+
+exports.down = pgm => {
+  pgm.sql(`DELETE FROM units_of_measure`)
+};

--- a/server/plugins/recipe-queries/index.js
+++ b/server/plugins/recipe-queries/index.js
@@ -114,7 +114,7 @@ const findUnitOfMeasureID = unit => {
     'pint',
     'pound',
     'quart',
-    'tablespoonw',
+    'tablespoon',
     'teaspoon'
   ];
 

--- a/server/plugins/recipe-queries/index.js
+++ b/server/plugins/recipe-queries/index.js
@@ -62,16 +62,18 @@ async function recipeQueries (fastify) {
         }
         return newInstructions
       })
+      const processedIngredients = processIngredients(ingredientList);
     
        const ingredients = await pg.transact(async client => {
         const newIngredients = []
-        for (const ingredient of ingredientList) {
+        // for (const ingredient of ingredientList) {
+        for (const ingredient of processedIngredients) {
           if (ingredient) {
             const { rows } = await client.query(`
               INSERT INTO ingredients (name) 
               VALUES ($1)
               RETURNING *;
-            `, [ingredient])
+            `, [ingredient.ingredient])
     
             const ingredientId = rows[0].id
     
@@ -79,7 +81,7 @@ async function recipeQueries (fastify) {
               INSERT INTO recipe_ingredients (recipe_id, ingredient_id, quantity, unit_of_measure_id) 
               VALUES ($1, $2, $3, $4)
               RETURNING *;
-            `, [recipeId, ingredientId, quantity, unitOfMeasure])
+            `, [recipeId, ingredientId, ingredient.quantity, ingredient.unitOfMeasure])
 
             newIngredients.push({
               ingredient: rows[0],
@@ -94,6 +96,109 @@ async function recipeQueries (fastify) {
       return { recipe: recipe[0], instructions, ingredients }
     }
   })
+}
+
+// hopefully converts a unit of measure: "cups" into an index value
+// this index value should match the cooresponding id in the
+// units_of_measure database table
+const findUnitOfMeasureID = unit => {
+  const units = [, // leave a blank space because the db starts at id:1
+    'each',
+    'cup',
+    'ounce',
+    'gallon',
+    'gram',
+    'kilogram',
+    'liter',
+    'milliliter',
+    'pint',
+    'pound',
+    'quart',
+    'tablespoonw',
+    'teaspoon'
+  ];
+
+  console.log('unit:', unit);
+
+  // if unit ends with an 's', remove it
+  if (unit.slice(unit.length - 1) === 's') {
+    unit = unit.slice(0, -1);
+  }
+
+  // look for unit in the array
+  unitsIndex = units.indexOf(unit); // returns -1 if not found
+
+  console.log('unit:', unit, 'index:', unitsIndex);
+  
+  // if not found, return 1 (indicating 'each')
+  return unitsIndex > 0 ? unitsIndex : 1
+}
+
+const processIngredients = ingredients => {
+
+  // console.log(str);
+
+  // split the string into an array based on new-line character
+  const ingArr = ingredients.split('\n');
+
+  const details = ingArr.map(e => {
+    return e.trim().split(' '); // split each line into an array of words
+  }).map(e => { // map each line into an array of [quantity, unit, ingredient]
+    // let quantity = 1;
+    // let unit = 'each';
+    // let ingredient = '';
+
+    console.log(e);
+
+    const obj = {
+      quantity: 1,
+      unitOfMeasure: 'each', // needs to be an ID from `select * from units_of_measure;`
+      ingredient: ''
+    }
+    
+    console.log('detail:', e);
+    
+    if (e.length === 1) { // single word
+      obj.ingredient = e[0];
+      // return [quantity, unit, ingredient];
+      obj.unitOfMeasure = findUnitOfMeasureID(obj.unitOfMeasure);
+      console.log(obj);
+      return obj;
+    }
+
+    if (e.length > 1) {
+
+      // if the first value isn't a number, use 1
+      if (!parseInt(e[0])) {
+        obj.quantity = 1
+        obj.ingredient = e.flat().join(' ');
+        obj.unitOfMeasure = findUnitOfMeasureID(obj.unitOfMeasure);
+        console.log(obj);
+        return obj;
+      }
+
+      obj.quantity = parseInt(e[0]);
+
+      const ofIndex = e.findIndex(e => e === 'of');
+
+      if (ofIndex === -1) { // 'of' not found
+        obj.ingredient = e.slice(1, e.length).flat().join(' ');
+      }
+
+      if ( ofIndex > 0) { // split array based on location of 'of'
+        obj.unitOfMeasure = e.slice(1, ofIndex).flat().join(' ');
+        obj.ingredient = e.slice(ofIndex + 1, e.length).flat().join(' ');
+      }
+
+      obj.unitOfMeasure = findUnitOfMeasureID(obj.unitOfMeasure);
+      // obj.unitOfMeasure = 1; // hack it in for now
+      console.log(obj);
+      return obj;
+    }
+    console.log('returning e???', e);
+    return e; // shouldn't get here
+  })
+  return details;
 }
 
 module.exports = fastifyPlugin(recipeQueries, {


### PR DESCRIPTION
This PR includes a migration to see the `units_of_measure` table. After running the migration ( `npm run migrate up` in `server/`) please confirm that your `units_of_measure` table matches exactly the following. If the IDs don't match there will be problems 😭

```
id |    unit
----+------------
  1 | each
  2 | cup
  3 | ounce
  4 | gallon
  5 | gram
  6 | kilogram
  7 | liter
  8 | milliliter
  9 | pint
 10 | pound
 11 | quart
 12 | tablespoon
 13 | teaspoon
```

turn this:
![image](https://user-images.githubusercontent.com/19153799/114798098-6c4b9c00-9d49-11eb-9f14-8c923197334b.png)
into this:
![image](https://user-images.githubusercontent.com/19153799/114798108-71a8e680-9d49-11eb-81a5-1ea7c97a9f98.png)
