### PR TITLE
Removes underline from browse button

### DIFF
--- a/client/src/routes/index.svelte
+++ b/client/src/routes/index.svelte
@@ -50,9 +50,9 @@
 
 	img {
 		display: block;
-  margin-left: auto;
-  margin-right: auto;
-  width: 30%;
+		margin-left: auto;
+		margin-right: auto;
+		width: 30%;
 	}
 
 	p, .home-buttons {
@@ -109,6 +109,11 @@
     text-align: center;
     border-radius: 15px;
   }
+
+	a {
+		text-decoration: none;
+	}
+	
 </style>
 
 <svelte:head>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/19153799/115436164-8a892000-a1bf-11eb-9dfa-819129514bcf.png)

After:
![image](https://user-images.githubusercontent.com/19153799/115436140-80672180-a1bf-11eb-8a1f-c12e4c761591.png)
